### PR TITLE
403 error handling

### DIFF
--- a/src/app/home/Profile.js
+++ b/src/app/home/Profile.js
@@ -39,7 +39,7 @@ const Profile = () => {
 
   if (error?.response.status === 403){
     return (
-      <div style={{display: "flex", height: "100vh", alignItems: "center"}}>
+      <div style={{display: "flex", height: "100vh", justifyContent: "center", alignItems: "center"}}>
         <p style={{textAlign: "center"}}>
             Looks like you don't have early access on this account!<br />
             Fear not, click the button below to log out from Spotify and try a different account.<br />

--- a/src/app/home/Profile.js
+++ b/src/app/home/Profile.js
@@ -1,14 +1,15 @@
 import { useState, useEffect } from "react";
-import { catchErrors } from "@/app/home/utils";
 import { getCurrentUserProfile, getCurrentUserPlaylists, getTopArtists, getTopTracks } from "@/app/home/spotify";
-import { StyledHeader } from "@/styles";
+import { StyledHeader, StyledLoginButton} from "@/styles";
 import { ArtistsGrid, PlaylistsGrid, SectionWrapper, TrackList, Loader } from "@/components";
+import { logoutEverywhere } from "@/app/home/spotify";
 
 const Profile = () => {
   const [profile, setProfile] = useState(null);
   const [playlists, setPlaylists] = useState(null);
   const [topArtists, setTopArtists] = useState(null);
   const [topTracks, setTopTracks] = useState(null);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -29,8 +30,25 @@ const Profile = () => {
       setTopTracks(userTopTracks.data);
     };
 
-    catchErrors(fetchData());
+    fetchData().catch((error) => {
+      console.log("Fetch Data Error: ", error)
+      setError(error)
+    });
+
   }, []);
+
+  if (error?.response.status === 403){
+    return (
+      <div style={{display: "flex", height: "100vh", alignItems: "center"}}>
+        <p style={{textAlign: "center"}}>
+            Looks like you don't have early access on this account!<br />
+            Fear not, click the button below to log out from Spotify and try a different account.<br />
+            <br />
+            <StyledLoginButton onClick={logoutEverywhere}>Log out everywhere</StyledLoginButton>
+        </p>
+      </div>
+    )
+  } 
 
   return (
     <>

--- a/src/app/home/Profile.js
+++ b/src/app/home/Profile.js
@@ -44,7 +44,7 @@ const Profile = () => {
             Looks like you don't have early access on this account!<br />
             Fear not, click the button below to log out from Spotify and try a different account.<br />
             <br />
-            <StyledLoginButton onClick={logoutEverywhere}>Log out everywhere</StyledLoginButton>
+            <StyledLoginButton onClick={logoutEverywhere}>Log out from Spotify</StyledLoginButton>
         </p>
       </div>
     )

--- a/src/app/home/spotify.js
+++ b/src/app/home/spotify.js
@@ -55,19 +55,10 @@ const clearAxiosHeaders = () => {
 }
 
 /**
- * Chooses correct logout function depending on profile type.
- * Assumes that if profileType.token is flase, profileType.staticProfile is true.
+ * Clears out localStorage and navigates to homepage.
  * @returns {void}
  */
 export const logout = () => {
-  profileType.token ? tokenLogout() : staticLogout();
-}
-
-/**
- * Static page logout: Clears out localStorage and navigates to homepage.
- * @returns {void}
- */
-export const staticLogout = () => {
   for (const property in LOCALSTORAGE_KEYS) {
     window.localStorage.removeItem(LOCALSTORAGE_KEYS[property]);
   }
@@ -76,11 +67,12 @@ export const staticLogout = () => {
 }
 
 /**
- * Early access logout: Logs out of spotify everywhere. 
+ * Logs out of spotify everywhere. 
  * Then clears localStorage and navigates to homepage.
+ * Currently used when encoutering 403 errors to let user log out and try again.
  * @returns {void}
  */
-export const tokenLogout = () => {
+export const logoutEverywhere = () => {
   const url = 'https://accounts.spotify.com/logout';
   const spotifyLogoutWindow = window.open(url, 'Spotify Logout');
   setTimeout(() => {


### PR DESCRIPTION
### Problem
Currently, we are logging out the user from Spotify whenever we click log out. This is bad UX since they now have to log in to Spotify manually every time they click "Log in with early access". This was a temporary way to allow users to log out of an unauthorized account (403); which there is still no message for.
### Solution
Handle 403 errors with a message telling the user they do not have access to TuneTrove with this account and giving them the option to log out from Spotify. We will revert the regular log out button to log out as before, by only removing things from localStorage.